### PR TITLE
✨ Feature - 날짜에 따른 로직을 처리하는 스케줄러 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.4.1",
+        "@nestjs/schedule": "^5.0.1",
         "@nestjs/swagger": "^7.4.0",
         "@nestjs/typeorm": "^10.0.2",
         "aws-sdk": "^2.1692.0",
@@ -1884,6 +1885,19 @@
         "@nestjs/core": "^10.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-5.0.1.tgz",
+      "integrity": "sha512-kFoel84I4RyS2LNPH6yHYTKxB16tb3auAEciFuc788C3ph6nABkUfzX5IE+unjVaRX+3GuruJwurNepMlHXpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "3.5.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "10.1.3",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.1.3.tgz",
@@ -2293,6 +2307,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -4094,6 +4114,16 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true
+    },
+    "node_modules/cron": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.5.0.tgz",
+      "integrity": "sha512-0eYZqCnapmxYcV06uktql93wNWdlTmmBFP2iYz+JPVcQqlyFYcn1lFuIk4R54pkOmE7mcldTAPZv6X5XA4Q46A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.4.0",
+        "luxon": "~3.5.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -7017,6 +7047,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.4.1",
+    "@nestjs/schedule": "^5.0.1",
     "@nestjs/swagger": "^7.4.0",
     "@nestjs/typeorm": "^10.0.2",
     "aws-sdk": "^2.1692.0",

--- a/src/idea/application/service/handle-period-transition-by-scheduler.service.ts
+++ b/src/idea/application/service/handle-period-transition-by-scheduler.service.ts
@@ -45,17 +45,17 @@ export class HandlePeriodTransitionBySchedulerService {
 
       // Phase1ConfirmationEnd의 하루 뒤인 경우
       if (isDayAfter(systemSetting.phase1ConfirmationEnd)) {
-        await this.processConfirmationTransition(4, 1, manager);
+        await this.processConfirmationTransition(Number(process.env.GENERATION), 1, manager);
       }
 
       // Phase2ConfirmationEnd의 하루 뒤인 경우
       if (isDayAfter(systemSetting.phase2ConfirmationEnd)) {
-        await this.processConfirmationTransition(4, 2, manager);
+        await this.processConfirmationTransition(Number(process.env.GENERATION), 2, manager);
       }
 
       // Phase3ConfirmationEnd의 하루 뒤인 경우
       if (isDayAfter(systemSetting.phase3ConfirmationEnd)) {
-        await this.processConfirmationTransition(4, 3, manager);
+        await this.processConfirmationTransition(Number(process.env.GENERATION), 3, manager);
       }
 
       this.logger.log('------------기간 전환 처리 완료. 로직 처리 이후, ' + systemSetting.getWhichPeriod() + '로 변경됨. ------------');

--- a/src/idea/application/service/handle-period-transition-by-scheduler.service.ts
+++ b/src/idea/application/service/handle-period-transition-by-scheduler.service.ts
@@ -1,0 +1,135 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ApplyRepository } from '../../repository/apply.repository';
+import { DataSource, EntityManager } from 'typeorm';
+import { MemberRepository } from '../../../team/repository/member.repository';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { SystemSettingRepository } from '../../../system-setting/repository/system-setting.repository';
+import { CommonException } from '../../../core/exceptions/common.exception';
+import { ErrorCode } from '../../../core/exceptions/error-code';
+import { EApplyStatus } from '../../../core/enums/apply-status.enum';
+import { ApplyModel } from '../../domain/apply.model';
+import { MemberModel } from '../../../team/domain/member.model';
+
+@Injectable()
+export class HandlePeriodTransitionBySchedulerService {
+  private readonly logger = new Logger(HandlePeriodTransitionBySchedulerService.name);
+
+  constructor(
+    private readonly systemSettingRepository: SystemSettingRepository,
+    private readonly applyRepository: ApplyRepository,
+    private readonly memberRepository: MemberRepository,
+    private readonly dataSource: DataSource,
+  ) {
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async handlePeriodTransitions(): Promise<void> {
+    return this.dataSource.transaction(async (manager) => {
+
+      // 시스템 설정 조회
+      const systemSetting = await this.systemSettingRepository.findFirst(manager);
+      if (!systemSetting) {
+        throw new CommonException(ErrorCode.NOT_FOUND_SYSTEM_SETTING);
+      }
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      // 특정 end 날짜의 하루 뒤가 오늘인지 확인
+      const isDayAfter = (endDate: Date): boolean => {
+        const nextDay = new Date(endDate);
+        nextDay.setHours(0, 0, 0, 0);
+        nextDay.setDate(nextDay.getDate() + 1);
+        return today.getTime() === nextDay.getTime();
+      };
+
+      // Phase1ConfirmationEnd의 하루 뒤인 경우
+      if (isDayAfter(systemSetting.phase1ConfirmationEnd)) {
+        await this.processConfirmationTransition(4, 1, manager);
+      }
+
+      // Phase2ConfirmationEnd의 하루 뒤인 경우
+      if (isDayAfter(systemSetting.phase2ConfirmationEnd)) {
+        await this.processConfirmationTransition(4, 2, manager);
+      }
+
+      // Phase3ConfirmationEnd의 하루 뒤인 경우
+      if (isDayAfter(systemSetting.phase3ConfirmationEnd)) {
+        await this.processConfirmationTransition(4, 3, manager);
+      }
+
+      this.logger.log('------------기간 전환 처리 완료. 로직 처리 이후, ' + systemSetting.getWhichPeriod() + '로 변경됨. ------------');
+    });
+  }
+
+  /**
+   * 해당 기수(generation)와 팀빌딩 차수(phase)에 해당하는 Apply들을 처리하는 로직
+   *
+   * 1. applyRepository.findByGenerationAndPhase(generation, phase)를 통해 모든 Apply 조회
+   * 2. WAITING 상태의 Apply들을 모두 REJECTED로 업데이트
+   * 3. ACCEPTED 상태의 Apply들을 사용자별로 그룹핑
+   *    - 만약 동일 사용자의 Apply가 여러 건이면, preference가 가장 낮은(숫자가 1에 가까운) Apply의 상태를 CONFIRMED로,
+   *      나머지는 ACCEPTED_NOT_JOINED로 업데이트하고, 각 경우에 대해 memberService.createMember()를 호출
+   *    - 동일 사용자가 단 1건이라면 해당 Apply의 상태를 CONFIRMED로 업데이트하고 member를 생성
+   */
+  private async processConfirmationTransition(generation: number, phase: number, manager: EntityManager): Promise<void> {
+    this.logger.log(`generation: ${generation}, phase: ${phase}에 대한 기간 전환 처리 시작`);
+
+    // 1. 해당 generation, phase에 해당하는 Apply들을 조회
+    const applies = await this.applyRepository.findByGenerationAndPhase(generation, phase, manager);
+    if (applies == null || applies.length === 0) {
+      this.logger.log(`generation: ${generation}, phase:${phase}에 대한 Apply가 없습니다.`);
+      return;
+    }
+
+    // 2. WAITING 상태의 Apply들은 REJECTED로 변경
+    for (const apply of applies) {
+      if (apply.status === EApplyStatus.WAITING) {
+        const updatedApply = apply.reject();
+        await this.applyRepository.save(updatedApply, manager);
+      }
+    }
+
+    // 3. ACCEPTED 상태의 Apply들 처리
+    const acceptedApplies = applies.filter(apply => apply.status === EApplyStatus.ACCEPTED);
+    if (acceptedApplies.length === 0) {
+      this.logger.log(`generation: ${generation}, phase: ${phase}에 대한 ACCEPTED 상태의 Apply가 없어, 스케쥴러를 종료합니다.`);
+      return;
+    }
+
+    // 그룹핑: user.id를 기준으로 그룹화 (여러 건이 있을 수 있음)
+    const groupedByUser = acceptedApplies.reduce((acc, apply) => {
+      const userId = apply.user.id;
+      if (!acc[userId]) {
+        acc[userId] = [];
+      }
+      acc[userId].push(apply);
+      return acc;
+    }, {} as Record<string, ApplyModel[]>);
+
+    // 각 사용자 그룹별로 처리
+    for (const userId in groupedByUser) {
+      const userApplies = groupedByUser[userId];
+      // preference가 낮은 순서로 정렬 (숫자가 작을수록 우선순위 높음)
+      userApplies.sort((a, b) => a.preference - b.preference);
+      // 첫 번째 Apply를 CONFIRMED로 변경
+      const confirmedApply = userApplies[0];
+      const updatedApply = confirmedApply.confirm();
+      await this.applyRepository.save(updatedApply);
+      // member 생성
+      const member = MemberModel.createMember(
+        confirmedApply.role,
+        confirmedApply.user,
+        confirmedApply.idea.team,
+      );
+
+      await this.memberRepository.save(member, manager);
+
+      // 동일 사용자에 대해 두 번째 이후의 Apply는 ACCEPTED_NOT_JOINED로 업데이트
+      for (let i = 1; i < userApplies.length; i++) {
+        const updatedApply = userApplies[i].acceptedNotJoined();
+        await this.applyRepository.save(updatedApply, manager);
+      }
+    }
+  }
+}

--- a/src/idea/domain/apply.model.ts
+++ b/src/idea/domain/apply.model.ts
@@ -73,4 +73,38 @@ export class ApplyModel {
       this.createdAt
     );
   }
+
+  public confirm(): ApplyModel {
+    if (this.status !== EApplyStatus.ACCEPTED) {
+      throw new CommonException(ErrorCode.APPLY_STATUS_ERROR);
+    }
+    return new ApplyModel(
+      this.id,
+      this.phase,
+      EApplyStatus.CONFIRMED,
+      this.preference,
+      this.motivation,
+      this.role,
+      this.user,
+      this.idea,
+      this.createdAt
+    );
+  }
+
+  public acceptedNotJoined(): ApplyModel {
+    if (this.status !== EApplyStatus.ACCEPTED) {
+      throw new CommonException(ErrorCode.APPLY_STATUS_ERROR);
+    }
+    return new ApplyModel(
+      this.id,
+      this.phase,
+      EApplyStatus.ACCEPTED_NOT_JOINED,
+      this.preference,
+      this.motivation,
+      this.role,
+      this.user,
+      this.idea,
+      this.createdAt
+    );
+  }
 }

--- a/src/idea/idea.module.ts
+++ b/src/idea/idea.module.ts
@@ -26,14 +26,18 @@ import { SystemSettingModule } from '../system-setting/system-setting.module';
 import { ReadRemainPreferenceBriefService } from './application/service/read-remain-preference-brief.service';
 import { UpdateIdeaService } from './application/service/update-idea.service';
 import { ReadMyApplyOverviewService } from './application/service/read-my-apply-overview.service';
-import { MemberRepository } from '../team/repository/member.repository';
 import { ReadTeamApplyOverviewService } from './application/service/read-team-apply-overview.service';
 import { AcceptApplyService } from './application/service/accept-apply.service';
 import { RejectApplyService } from './application/service/reject-apply.service';
 import { CancelApplyService } from './application/service/cancel-apply.service';
+import { ScheduleModule } from '@nestjs/schedule';
+import {
+  HandlePeriodTransitionBySchedulerService
+} from './application/service/handle-period-transition-by-scheduler.service';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
     DatabaseModule,
     TypeOrmModule.forFeature(
       [IdeaEntity]
@@ -50,6 +54,7 @@ import { CancelApplyService } from './application/service/cancel-apply.service';
     IdeaQueryV1Controller
   ],
   providers: [
+    HandlePeriodTransitionBySchedulerService,
     CreateIdeaService,
     CreateIdeaSubjectService,
     UpdateIdeaSubjectIsActiveService,

--- a/src/idea/repository/apply.repository.ts
+++ b/src/idea/repository/apply.repository.ts
@@ -59,6 +59,19 @@ export class ApplyRepository {
     return entities.length !== 0 ? ApplyMapper.toDomains(entities) : null;
   }
 
+  async findByGenerationAndPhase(generation: number, phase: number, manager?: EntityManager): Promise<ApplyModel[] | null> {
+    const repo = manager ? manager.getRepository(ApplyEntity) : this.dataSource.getRepository(ApplyEntity);
+
+    const entities = await repo.find(
+      {
+        where: { idea: { generation }, phase },
+        relations: ['user', 'user.univ', 'idea', 'idea.provider', 'idea.ideaSubject', 'idea.team']
+      }
+    );
+
+    return entities.length !== 0 ? ApplyMapper.toDomains(entities) : null;
+  }
+
   async findByUserIdAndIdeaId(userId: number, ideaId: number, manager?: EntityManager): Promise<ApplyModel | null> {
     const repo = manager ? manager.getRepository(ApplyEntity) : this.dataSource.getRepository(ApplyEntity);
 


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #175 

어떤 변경사항이 있었나요?
- [x] ✨ Feature: New feature
- [ ] 🔨 Fix: Feature change or bug fix
- [ ] 💻 CrossBrowsing: Browser compatibility
- [ ] 🌏 Deploy: Deploy
- [ ] 🎨 Design: Markup & styling
- [ ] 📃 Docs: Documentation writing and editing (README.md, etc.)
- [ ] ♻️ Refactor: Code refactoring
- [ ] ⚙️ Setting: Development environment setup
- [ ] ✅ Test: Test related (storybook, jest, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] 코드가 정상적으로 동작합니다. (필수)
- [ ] 코드 리뷰어에게 리뷰를 요청했습니다. (필수)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
작업 내용을 작성해주세요.
한국시간 매일 자정마다, 오늘이 DB의 특정 기간의 End 날짜보다 하루 뒤의 날짜를 확인한다.

IdeaSubmissionEnd의 하루 뒤 날이라면 : 아무것도 하지 않음
Phase1TeamBuildingEnd의 하루 뒤 날이라면: 아무것도 하지 않음
Phase1ConfirmationEnd의 하루 뒤 날이라면:
generation = 4, phase = 1로 applyRepository에서 findByGenerationAndPhase를 통해 해당 기수의 해당 팀빌딩 차수에 지원된 모든 Apply들을 조회한다.
Apply들 중, status가 WAITING인 데이터를 전부 REJECTED로 변경한다.
status가 ACCEPTED인 데이터들 리스트를 순환하며 아래의 로직을 수행한다.
ACCEPTED인 Apply들 중, apply.user가 현재의 것과 동일한게 있는지 확인.
-> 여기에서 동일한게 있다면, 전부 가져와서 apply.preference를 비교하고, preference가 가장 적은(1에 가까운) Apply의 status를 CONFIRMED로 바꾸고 나머지의 status를 ACCEPTED_NOT_JOINED로 변경하고, member.team = apply.idea.team, member.user = apply.user, member.role = apply.role로 하는 member를 생성한 후 다음 순환으로 넘어감.
-> 동일한게 없다면 해당 Apply의 status를 CONFIRMED로 변경하고, member.team = apply.idea.team, member.user = apply.user, member.role = apply.role로 하는 member를 생성한 후 다음 순환으로 넘어감.

Phase2TeamBuildingEnd의 하루 뒤 날이라면: 아무것도 하지 않음
Phase2ConfirmationEnd의 하루 뒤 날이라면:
generation = 4, phase = 2로 applyRepository에서 findByGenerationAndPhase를 통해 해당 기수의 해당 팀빌딩 차수에 지원된 모든 Apply들을 조회한다.
Apply들 중, status가 WAITING인 데이터를 전부 REJECTED로 변경한다.
status가 ACCEPTED인 데이터들 리스트를 순환하며 아래의 로직을 수행한다.
ACCEPTED인 Apply들 중, apply.user가 현재의 것과 동일한게 있는지 확인.
-> 여기에서 동일한게 있다면, 전부 가져와서 apply.preference를 비교하고, preference가 가장 적은(1에 가까운) Apply의 status를 CONFIRMED로 바꾸고 나머지의 status를 ACCEPTED_NOT_JOINED로 변경하고, member.team = apply.idea.team, member.user = apply.user, member.role = apply.role로 하는 member를 생성한 후 다음 순환으로 넘어감.
-> 동일한게 없다면 해당 Apply의 status를 CONFIRMED로 변경하고, member.team = apply.idea.team, member.user = apply.user, member.role = apply.role로 하는 member를 생성한 후 다음 순환으로 넘어감.

Phase3TeamBuildingEnd의 하루 뒤 날이라면: 아무것도 하지 않음
Phase3ConfirmationEnd의 하루 뒤 날이라면:
generation = 4, phase = 3로 applyRepository에서 findByGenerationAndPhase를 통해 해당 기수의 해당 팀빌딩 차수에 지원된 모든 Apply들을 조회한다.
Apply들 중, status가 WAITING인 데이터를 전부 REJECTED로 변경한다.
status가 ACCEPTED인 데이터들 리스트를 순환하며 아래의 로직을 수행한다.
ACCEPTED인 Apply들 중, apply.user가 현재의 것과 동일한게 있는지 확인.
-> 여기에서 동일한게 있다면, 전부 가져와서 apply.preference를 비교하고, preference가 가장 적은(1에 가까운) Apply의 status를 CONFIRMED로 바꾸고 나머지의 status를 ACCEPTED_NOT_JOINED로 변경하고, member.team = apply.idea.team, member.user = apply.user, member.role = apply.role로 하는 member를 생성한 후 다음 순환으로 넘어감.
-> 동일한게 없다면 해당 Apply의 status를 CONFIRMED로 변경하고, member.team = apply.idea.team, member.user = apply.user, member.role = apply.role로 하는 member를 생성한 후 다음 순환으로 넘어감.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
없다면 N/A를 작성해주세요.
N/A

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
리뷰어가 알면 좋은 내용을 작성해주세요.
